### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2](https://github.com/20jasper/gcg-parser/compare/v0.1.1...v0.1.2) - 2024-02-09
 
 ### Other
-- update documentation link and remove duplicate keywords
-- Publish dry run in ci ([#16](https://github.com/20jasper/gcg-parser/pull/16))
+- update crates.io documentation link and remove duplicate keywords
 
 ## [0.1.1](https://github.com/20jasper/gcg-parser/compare/v0.1.0...v0.1.1) - 2024-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/20jasper/gcg-parser/compare/v0.1.1...v0.1.2) - 2024-02-09
+
+### Other
+- update documentation link and remove duplicate keywords
+- Publish dry run in ci ([#16](https://github.com/20jasper/gcg-parser/pull/16))
+
 ## [0.1.1](https://github.com/20jasper/gcg-parser/compare/v0.1.0...v0.1.1) - 2024-02-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "A parser for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/20jasper/gcg-parser/compare/v0.1.1...v0.1.2) - 2024-02-09

### Other
- update documentation link and remove duplicate keywords
- Publish dry run in ci ([#16](https://github.com/20jasper/gcg-parser/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).