### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/20jasper/gcg-parser/compare/v0.1.2...v0.1.3) - 2024-02-09
+
+### Added
+- feat debug print text in GcgError message
+
+### Other
+- add errors heading for Player::build
+- add doc test for Player::build
+
 ## [0.1.2](https://github.com/20jasper/gcg-parser/compare/v0.1.1...v0.1.2) - 2024-02-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "A parser for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/20jasper/gcg-parser/compare/v0.1.2...v0.1.3) - 2024-02-09

### Added
- feat debug print text in GcgError message

### Other
- add errors heading for Player::build
- add doc test for Player::build
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).