### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/20jasper/gcg-parser/compare/v0.1.3...v0.1.4) - 2024-02-10
+
+### Other
+- update crate level documentation
+- add intradoc link to Player::build
+
 ## [0.1.3](https://github.com/20jasper/gcg-parser/compare/v0.1.2...v0.1.3) - 2024-02-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "A parser for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/20jasper/gcg-parser/compare/v0.1.3...v0.1.4) - 2024-02-10

### Other
- update crate level documentation
- add intradoc link to Player::build
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).