### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0](https://github.com/20jasper/gcg-parser/compare/v0.1.4...v0.2.0) - 2024-02-10
 
+### Deprecated
+- remove Player from public API
+- change GcgError position field to token_index
+
+### Added
+- parse multiple lines. Adds error variant
+- and add line_index field
+
+### Fixed
+- handle unknown pragma. Adds error variant
+
 ### Documentation
 - update changelog format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/20jasper/gcg-parser/compare/v0.1.4...v0.2.0) - 2024-02-10
+
+### Documentation
+- update changelog format
+
 ## [0.1.4](https://github.com/20jasper/gcg-parser/compare/v0.1.3...v0.1.4) - 2024-02-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "A parser for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.1.4 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `gcg-parser` breaking changes

```
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field token_index of variant GcgError::MissingToken in /tmp/.tmpRNAU7L/gcg-parser/src/error.rs:11
  field line_index of variant GcgError::MissingToken in /tmp/.tmpRNAU7L/gcg-parser/src/error.rs:13

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field position of variant GcgError::MissingToken, previously in file /tmp/.tmpSdRXCC/gcg-parser/src/error.rs:11

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/enum_variant_added.ron

Failed in:
  variant GcgError:MissingPragma in /tmp/.tmpRNAU7L/gcg-parser/src/error.rs:17
  variant GcgError:UnknownPragma in /tmp/.tmpRNAU7L/gcg-parser/src/error.rs:22

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/struct_missing.ron

Failed in:
  struct gcg_parser::Player, previously in file /tmp/.tmpSdRXCC/gcg-parser/src/lib.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/20jasper/gcg-parser/compare/v0.1.4...v0.2.0) - 2024-02-10

### Documentation
- update changelog format
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).