### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/20jasper/gcg-parser/compare/v0.2.0...v0.3.0) - 2024-02-16
+
+### Added
+- [**breaking**] parse #description pragma
+
 ## [0.2.0](https://github.com/20jasper/gcg-parser/compare/v0.1.4...v0.2.0) - 2024-02-10
 
 ### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "A parser for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `gcg-parser` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Gcg.description in /tmp/.tmp0dtmg9/gcg-parser/src/lib.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/20jasper/gcg-parser/compare/v0.2.0...v0.3.0) - 2024-02-16

### Added
- [**breaking**] parse #description pragma
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).