### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0](https://github.com/20jasper/gcg-parser/compare/v0.3.0...v0.4.0) - 2024-03-03
 
 ### Added
-- [**breaking**] parse coordinates ([#41](https://github.com/20jasper/gcg-parser/pull/41))
+- [**breaking**] Add `Coordinates` struct to parse event coordinates ([#41](https://github.com/20jasper/gcg-parser/pull/41))
 
 ## [0.3.0](https://github.com/20jasper/gcg-parser/compare/v0.2.0...v0.3.0) - 2024-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/20jasper/gcg-parser/compare/v0.3.0...v0.4.0) - 2024-03-03
+
+### Added
+- [**breaking**] parse coordinates ([#41](https://github.com/20jasper/gcg-parser/pull/41))
+
 ## [0.3.0](https://github.com/20jasper/gcg-parser/compare/v0.2.0...v0.3.0) - 2024-02-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "A parser for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `gcg-parser` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_added.ron

Failed in:
  variant GcgError:InvalidToken in /tmp/.tmpC2lHvb/gcg-parser/src/error.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/20jasper/gcg-parser/compare/v0.3.0...v0.4.0) - 2024-03-03

### Added
- [**breaking**] parse coordinates ([#41](https://github.com/20jasper/gcg-parser/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).