### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/20jasper/gcg-parser/compare/v0.4.0...v0.5.0) - 2024-03-05
+
+### Documentation
+- add doctest to Player
+
+### Refactor
+- [**breaking**] split GcgError into gcg::error and token::error. Added InvalidLine error ([#45](https://github.com/20jasper/gcg-parser/pull/45))
+
+### Added
+- add Player struct
+
+### Fixed
+- display print instead of debug InvalidLine Error ([#46](https://github.com/20jasper/gcg-parser/pull/46))
+
+### Remove
+- [**breaking**] remove line field from MissingToken error
+
 ## [0.4.0](https://github.com/20jasper/gcg-parser/compare/v0.3.0...v0.4.0) - 2024-03-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0](https://github.com/20jasper/gcg-parser/compare/v0.4.0...v0.5.0) - 2024-03-05
 
 ### Documentation
-- add doctest to Player
+- Player doctest
 
 ### Refactor
-- [**breaking**] split GcgError into gcg::error and token::error. Added InvalidLine error ([#45](https://github.com/20jasper/gcg-parser/pull/45))
+- [**breaking**] split GcgError into gcg::error and token::error
 
 ### Added
-- add Player struct
+- Player struct and parsing
+- InvalidLine error ([#45](https://github.com/20jasper/gcg-parser/pull/45))
 
 ### Fixed
 - display print instead of debug InvalidLine Error ([#46](https://github.com/20jasper/gcg-parser/pull/46))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "Parser and Data Structures for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.4.0 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `gcg-parser` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_missing.ron

Failed in:
  enum gcg_parser::error::GcgError, previously in file /tmp/.tmpWZ9xiU/gcg-parser/src/error.rs:6
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/20jasper/gcg-parser/compare/v0.4.0...v0.5.0) - 2024-03-05

### Documentation
- Player doctest

### Refactor
- [**breaking**] split GcgError into gcg::error and token::error

### Added
- Player struct and parsing
- InvalidLine error ([#45](https://github.com/20jasper/gcg-parser/pull/45))

### Fixed
- display print instead of debug InvalidLine Error ([#46](https://github.com/20jasper/gcg-parser/pull/46))

### Remove
- [**breaking**] remove line field from MissingToken error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).