### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/20jasper/gcg-parser/compare/v0.5.0...v0.5.1) - 2024-03-05
+
+### Fixed
+- package metadata: categories ([#49](https://github.com/20jasper/gcg-parser/pull/49))
+
 ## [0.5.0](https://github.com/20jasper/gcg-parser/compare/v0.4.0...v0.5.0) - 2024-03-05
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "gcg-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcg-parser"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 description = "Parser and Data Structures for the GCG file format"
 documentation = "https://docs.rs/gcg-parser/latest/gcg_parser/index.html"


### PR DESCRIPTION
## 🤖 New release
* `gcg-parser`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/20jasper/gcg-parser/compare/v0.5.0...v0.5.1) - 2024-03-05

### Fixed
- package metadata: categories ([#49](https://github.com/20jasper/gcg-parser/pull/49))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).